### PR TITLE
Disable pytest command in linter.yml

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -30,4 +30,4 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-        ./pytest_single.sh test_math_operations.py
+        # ./pytest_single.sh test_math_operations.py


### PR DESCRIPTION
Comment out the pytest_single.sh command in linter workflow.